### PR TITLE
Change RPC port to non-default during tests

### DIFF
--- a/t/test.pl
+++ b/t/test.pl
@@ -24,6 +24,7 @@ BEGIN {
 }
 
 const my $PORT          => 17755;
+const my $RPCPORT       => 17756;
 const my $TMPDIR_HANDLE => File::Temp->newdir(CLEANUP => 1);
 const my $TMPDIR        => $TMPDIR_HANDLE->dirname();
 
@@ -169,6 +170,7 @@ sub test_argument_checking {
 sub get_test_conf {
     return <<"END";
 reporting-disabled = true
+bind-address = ":$RPCPORT"
 
 [logging]
   level = "warn"


### PR DESCRIPTION
Running the tests on a host that already has an instance running with the default ports will cause an issue with binding to the RPC port. By using a non-default port we'll ensure that the test run won't fail before starting.